### PR TITLE
Support for nullable data types

### DIFF
--- a/Dapper.MoqTests.Samples/Car.cs
+++ b/Dapper.MoqTests.Samples/Car.cs
@@ -1,4 +1,6 @@
-﻿namespace Dapper.MoqTests.Samples
+﻿using System;
+
+namespace Dapper.MoqTests.Samples
 {
     // ReSharper disable UnusedAutoPropertyAccessor.Global
     public class Car
@@ -6,5 +8,6 @@
         public string Registration { get; set; }
         public string Make { get; set; }
         public string Model { get; set; }
+        public DateTime? DateRegistered { get; set; }
     }
 }

--- a/Dapper.MoqTests.Samples/Samples.cs
+++ b/Dapper.MoqTests.Samples/Samples.cs
@@ -197,13 +197,15 @@ where Registration = @registration", new { registration = "ABC123" }, null, null
             {
                 Registration = "ABC123",
                 Make = "Vauxhall",
-                Model = "Astra"
+                Model = "Astra",
+                DateRegistered = null,
             };
             var ford = new Car
             {
                 Registration = "DEF456",
                 Make = "Ford",
-                Model = "Mondeo"
+                Model = "Mondeo",
+                DateRegistered = new DateTime(2022, 2, 1, 12, 11, 10),
             };
             connectionFactory
                 .Setup(f => f.OpenConnection())
@@ -215,6 +217,7 @@ order by Make, Model", It.IsAny<object>(), It.IsAny<IDbTransaction>(), true, nul
 
             var result = repository.GetCars();
 
+            Assert.That(result.Select(c => c.DateRegistered), Is.EquivalentTo(new DateTime?[] { null, new DateTime(2022, 2, 1, 12, 11, 10) }));
             Assert.That(result.Select(c => c.Model), Is.EquivalentTo(new[] { "Astra", "Mondeo" }));
         }
 


### PR DESCRIPTION
Hello, I noticed that nullable DateTime properties were not being copied in `ObjectExtensions.GetDataReader`. This change should add support for any properties of complex types that are nullables of a primitive type.