### PR TITLE
Feature fix `QueryAsync` setup

### DIFF
--- a/Dapper.MoqTests.Samples/Samples.cs
+++ b/Dapper.MoqTests.Samples/Samples.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Dapper.MoqTests.Samples

--- a/Dapper.MoqTests.Samples/Samples.cs
+++ b/Dapper.MoqTests.Samples/Samples.cs
@@ -61,7 +61,20 @@ order by Make, Model", It.IsAny<object>(), It.IsAny<IDbTransaction>(), true, nul
                 .Setup(f => f.OpenConnection())
                 .Returns(connection);
 
-            await repository.GetCarsAsync();
+            var expectedCars = new List<Car>
+            {
+                new Car { Registration = "ABC123", Make = "Vauxhall", Model = "Astra" },
+                new Car { Registration = "DEF456", Make = "Ford", Model = "Mondeo" }
+            };
+            connection.Setup(c => c.QueryAsync<Car>(@"select *
+from [Cars]
+order by Make, Model", null, null, null, null)).ReturnsAsync(expectedCars);
+
+            var result = await repository.GetCarsAsync();
+
+            Assert.That(result.Select(c => c.Registration), Is.EquivalentTo(new[] { "ABC123", "DEF456" }));
+            Assert.That(result.Select(c => c.Make), Is.EquivalentTo(new[] { "Vauxhall", "Ford" }));
+            Assert.That(result.Select(c => c.Model), Is.EquivalentTo(new[] { "Astra", "Mondeo" }));
 
             connection.Verify(c => c.QueryAsync<Car>(@"select *
 from [Cars]

--- a/Dapper.MoqTests/MockDatabase/MockDatabase.cs
+++ b/Dapper.MoqTests/MockDatabase/MockDatabase.cs
@@ -60,7 +60,9 @@ namespace Dapper.MoqTests
             var parametersLookup = command.GetParameterLookup(isAsync, cancellationToken);
             var parametersArray = method.GetValues(parametersLookup);
 
-            var result = method.Invoke(this, parametersArray);
+            var result = isAsync 
+                ? TaskHelper.GetResultOfTask(method.Invoke(this, parametersArray))
+                : method.Invoke(this, parametersArray);
             var reader = result as IDataReader;
             if (result == null)
             {


### PR DESCRIPTION
Fixed setup and verification of the `QueryAsync` extension.

- Updated `MockDatabase->ExecuteReader` to actually utilize the `isAsync` param and return result respectively for async invocations
- Updated unit tests in `Sample.cs`